### PR TITLE
Adds support for B2BKing (price groups & visibility)

### DIFF
--- a/includes/shortcode.php
+++ b/includes/shortcode.php
@@ -282,13 +282,27 @@ if( !function_exists( 'wpt_shortcode_generator' ) ){
             $args['order'] = $sort;
         }
 
+        /**
+         * Check if B2BKing plugin installed
+         * and use B2BKing's group-pricing support if applicable  */ 
+        $user_id = get_current_user_id();
+        $b2bking_plugin_enabled = (get_user_meta($user_id, 'b2bking_b2buser', true) === 'yes');
 
+        // set key to use for Minimum and Maximum price query 
+        if ($b2bking_plugin_enabled){ //B2BKing
+            $b2bking_user_group = get_user_meta($user_id, 'b2bking_customergroup', true);
+            $query_price_key = 'b2bking_regular_product_price_group_'.$b2bking_user_group; 
+        } else {
+            $query_price_key = '_price'; //default
+        }
+        
         /**
          * Set Minimum Price for
          */
-        if ($min_price) {
+     	if ($min_price) {
             $args['meta_query'][] = array(
-                'key' => '_price',
+            //default price handling or B2Bking group prices
+                'key' => $query_price_key,
                 'value' => $min_price,
                 'compare' => '>=',
                 'type' => 'NUMERIC'
@@ -299,12 +313,28 @@ if( !function_exists( 'wpt_shortcode_generator' ) ){
          * Set Maximum Price for
          */
         if ($max_price) {
+          //default price handling
             $args['meta_query'][] = array(
-                'key' => '_price',
+                'key' => $query_price_key,
                 'value' => $max_price,
                 'compare' => '<=',
                 'type' => 'NUMERIC'
             );
+        }
+
+        /**
+         * Args Set for tax_query if available $product_cat_ids
+         * 
+         * @since 1.0
+         */
+        if ($product_cat_ids) {
+            $args['tax_query']['product_cat_IN'] = array(  //product_cat_IN Added at 5.7 for javascript help work
+                    'taxonomy' => 'product_cat',
+                    'field' => 'id',
+                    'terms' => $product_cat_ids,
+                    'operator' => 'IN'
+                );
+
         }
 
         /**
@@ -370,7 +400,17 @@ if( !function_exists( 'wpt_shortcode_generator' ) ){
             $sale_products = $sale_products && is_array( $sale_products ) && $post_include && is_array( $post_include ) ? array_intersect( $post_include, $sale_products ) : $sale_products;
             $args['post__in'] = $sale_products;//var_dump(wc_get_product_ids_on_sale());
         }
-
+	
+	/**
+         * B2BKing: include only visible posts 
+         * (set in B2BKing user settings on either group or user level)
+         */
+        if($b2bking_plugin_enabled){
+            $b2bking_visible_ids = get_transient('b2bking_user_'.get_current_user_id().'_ajax_visibility');
+            $b2bking_visible_ids = $args['post__in'] && is_array( $args['post__in'] ) ? array_intersect($args['post__in'], $b2bking_visible_ids): $b2bking_visible_ids;
+            $args['post__in'] = $b2bking_visible_ids;
+        }
+		 
         /**
          * Post Exlucde
          * 


### PR DESCRIPTION
This update adds compatibility with the popular Woocommerce extension B2BKing (https://woocommerce-b2b-plugin.com/).
B2BKing offers customer-group pricing (min/max) and lets you set group-level product visibility. Both these functions did not work properly with the original Woo-product-table code. The modifications that allow the plugins to cooperate correctly are based on direct advice of the official support team and have been successfully tested.